### PR TITLE
[Bug Fix] TabBar text color

### DIFF
--- a/lib/giphy_get.dart
+++ b/lib/giphy_get.dart
@@ -39,6 +39,8 @@ class GiphyGet {
     bool showStickers = true,
     bool showEmojis = true,
     Color? tabColor,
+    Color? textSelectedColor,
+    Color? textUnselectedColor,
     int debounceTimeInMilliseconds = 350,
   }) {
     if (apiKey == "") {
@@ -70,6 +72,10 @@ class GiphyGet {
               apiKey: apiKey,
               randomID: randomID,
               tabColor: tabColor ?? Theme.of(context).colorScheme.secondary,
+              textSelectedColor: textSelectedColor ??
+                  Theme.of(context).textTheme.titleSmall?.color,
+              textUnselectedColor: textUnselectedColor ??
+                  Theme.of(context).textTheme.bodySmall?.color,
               searchText: searchText,
               rating: rating,
               lang: lang,

--- a/lib/src/providers/tab_provider.dart
+++ b/lib/src/providers/tab_provider.dart
@@ -5,6 +5,8 @@ import 'package:giphy_get/src/client/models/rating.dart';
 class TabProvider with ChangeNotifier {
   String apiKey;
   Color? tabColor;
+  Color? textSelectedColor;
+  Color? textUnselectedColor;
   String? searchText;
   String rating = GiphyRating.g;
   String lang = GiphyLanguage.english;
@@ -20,6 +22,8 @@ class TabProvider with ChangeNotifier {
   TabProvider({
     required this.apiKey,
     this.tabColor,
+    this.textSelectedColor,
+    this.textUnselectedColor,
     this.searchText,
     required this.rating,
     required this.randomID,

--- a/lib/src/views/tab/giphy_tab_bar.dart
+++ b/lib/src/views/tab/giphy_tab_bar.dart
@@ -85,6 +85,9 @@ class _GiphyTabBarState extends State<GiphyTabBar> {
     return Padding(
       padding: const EdgeInsets.only(bottom: 5.0),
       child: TabBar(
+        indicatorColor: _tabProvider.tabColor,
+        labelColor: _tabProvider.textSelectedColor,
+        unselectedLabelColor: _tabProvider.textUnselectedColor,
         indicatorSize: TabBarIndicatorSize.label,
         controller: widget.tabController,
         tabs: _tabs.map((e) => e.tab).toList(),


### PR DESCRIPTION
### Changes

* Fix default colors of the TabBar texts
* Added two more properties for allowing more customization: `textSelectedColor` and  `textUnselectedColor`
* Fix: `tabColor` was not used for the indicator

fixes #47 