### PR TITLE
emojies 100 > limit - Update giphy_tab_detail.dart

### DIFF
--- a/lib/src/views/tab/giphy_tab_detail.dart
+++ b/lib/src/views/tab/giphy_tab_detail.dart
@@ -97,7 +97,7 @@ class _GiphyTabDetailState extends State<GiphyTabDetail> {
         ((MediaQuery.of(context).size.height - 30) / _gifWidth).round();
 
     _limit = _crossAxisCount * _mainAxisCount;
-
+    if (_limit > 100) _limit = 100;
     // Initial offset
     offset = 0;
 


### PR DESCRIPTION
With _limit based on screen size automatically set for emoji, the result for desktop is 117. When api.giphy sees a _limit value above 100, it returns an empty result. so when _limit exceeds 100 it is fixed to 100.